### PR TITLE
Update description on how to use the toolchain script in the Github actions

### DIFF
--- a/scripts/setup-custom-toolchain.sh
+++ b/scripts/setup-custom-toolchain.sh
@@ -3,8 +3,8 @@
 # This is an example script that can be used to install additional toolchain dependencies. Feel free to remove this script
 # if no additional toolchains are required
 
-# To enable this script, set the `custom_toolchain_script` option to true when calling the reusable workflow
-# `.github/workflows/_extension_distribution.yml` from `https://github.com/duckdb/extension-ci-tools`
+# To use this script in CI github actions, you would need to override the ´configure_ci´ target in your makefile and have it call this script 
+# e.g. 'bash ./scripts/setup-custom-toolchain.sh'
 
 # note that the $DUCKDB_PLATFORM environment variable can be used to discern between the platforms
 echo "This is the sample custom toolchain script running for architecture '$DUCKDB_PLATFORM' for the quack extension."

--- a/scripts/setup-custom-toolchain.sh
+++ b/scripts/setup-custom-toolchain.sh
@@ -3,8 +3,9 @@
 # This is an example script that can be used to install additional toolchain dependencies. Feel free to remove this script
 # if no additional toolchains are required
 
-# To use this script in CI github actions, you would need to override the ´configure_ci´ target in your makefile and have it call this script 
-# e.g. 'bash ./scripts/setup-custom-toolchain.sh'
+# To use this script in the GitHub Actions setup, override the `configure_ci` target in your Makefile
+# and have it call this script.
+# Example: `bash ./scripts/setup-custom-toolchain.sh`
 
 # note that the $DUCKDB_PLATFORM environment variable can be used to discern between the platforms
 echo "This is the sample custom toolchain script running for architecture '$DUCKDB_PLATFORM' for the quack extension."


### PR DESCRIPTION

# What has been changed?

The description within the `./scripts/install-custom-toolchain.sh` file was wrong since it was describing the old way to activate the script.
So now the description is updated to help the user to use the new way of activating the script.

### Commits
- **Update description in the custom toolchain script**
- **Make additional adjustments to the description**
